### PR TITLE
Add heartbeat support and configurable session timeout

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "maxSessions": 20,
   "maxUsersPerSession": 10,
   "snapshotIntervalSec": 30,
+  "sessionTimeoutSec": 30,
   "databaseURL": "postgres://quicktt:quicktt@localhost:5432/quicktabletop?sslmode=disable"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	MaxSessions        int    `json:"maxSessions"`
 	MaxUsersPerSession int    `json:"maxUsersPerSession"`
 	SnapshotIntervalSec int   `json:"snapshotIntervalSec"`
+	SessionTimeoutSec  int    `json:"sessionTimeoutSec"`
 	DatabaseURL        string `json:"databaseURL"`
 }
 
@@ -18,6 +19,7 @@ func DefaultConfig() Config {
 		MaxSessions:        5,
 		MaxUsersPerSession: 10,
 		SnapshotIntervalSec: 30,
+		SessionTimeoutSec:  30,
 		DatabaseURL:        "postgres://quicktt:quicktt@localhost:5432/quicktabletop?sslmode=disable",
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.SnapshotIntervalSec != 30 {
 		t.Errorf("expected SnapshotIntervalSec 30, got %d", cfg.SnapshotIntervalSec)
 	}
+	if cfg.SessionTimeoutSec != 30 {
+		t.Errorf("expected SessionTimeoutSec 30, got %d", cfg.SessionTimeoutSec)
+	}
 	if cfg.DatabaseURL != "postgres://quicktt:quicktt@localhost:5432/quicktabletop?sslmode=disable" {
 		t.Errorf("unexpected DatabaseURL: %q", cfg.DatabaseURL)
 	}
@@ -31,6 +34,7 @@ func TestLoadValidFile(t *testing.T) {
 		"maxSessions": 20,
 		"maxUsersPerSession": 50,
 		"snapshotIntervalSec": 60,
+		"sessionTimeoutSec": 45,
 		"databaseURL": "postgres://user:pass@host:5432/db"
 	}`
 	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
@@ -47,6 +51,9 @@ func TestLoadValidFile(t *testing.T) {
 	}
 	if cfg.SnapshotIntervalSec != 60 {
 		t.Errorf("expected SnapshotIntervalSec 60, got %d", cfg.SnapshotIntervalSec)
+	}
+	if cfg.SessionTimeoutSec != 45 {
+		t.Errorf("expected SessionTimeoutSec 45, got %d", cfg.SessionTimeoutSec)
 	}
 	if cfg.DatabaseURL != "postgres://user:pass@host:5432/db" {
 		t.Errorf("unexpected DatabaseURL: %q", cfg.DatabaseURL)
@@ -99,6 +106,9 @@ func TestLoadPartialJSON(t *testing.T) {
 	}
 	if cfg.SnapshotIntervalSec != 30 {
 		t.Errorf("expected default SnapshotIntervalSec 30, got %d", cfg.SnapshotIntervalSec)
+	}
+	if cfg.SessionTimeoutSec != 30 {
+		t.Errorf("expected default SessionTimeoutSec 30, got %d", cfg.SessionTimeoutSec)
 	}
 	if cfg.DatabaseURL != "postgres://quicktt:quicktt@localhost:5432/quicktabletop?sslmode=disable" {
 		t.Errorf("expected default DatabaseURL, got %q", cfg.DatabaseURL)

--- a/session/session.go
+++ b/session/session.go
@@ -235,7 +235,8 @@ func (m *Manager) HandleWS(c *websocket.Conn) {
 		m.mu.Unlock()
 
 		if remaining == 0 {
-			time.AfterFunc(2*time.Second, func() {
+			timeout := time.Duration(m.cfg.SessionTimeoutSec) * time.Second
+			time.AfterFunc(timeout, func() {
 				m.mu.Lock()
 				defer m.mu.Unlock()
 				s, ok := m.sessions[sessionId]
@@ -257,6 +258,10 @@ func (m *Manager) HandleWS(c *websocket.Conn) {
 		var clientMsg ClientMessage
 		if err := json.Unmarshal(msg, &clientMsg); err != nil {
 			log.Println("invalid message:", err)
+			continue
+		}
+
+		if clientMsg.Type == "ping" {
 			continue
 		}
 


### PR DESCRIPTION
Client ping messages are handled without broadcasting state. Session cleanup timeout increased from 2s to configurable SessionTimeoutSec (default 30s) to survive brief disconnects.