### PR TITLE
Set WebSocket read limit to prevent oversized messages

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -196,6 +196,7 @@ func (m *Manager) GetSession(c *fiber.Ctx) error {
 
 // WS handler
 func (m *Manager) HandleWS(c *websocket.Conn) {
+	c.SetReadLimit(4096) // 4KB max message size
 	sessionId := c.Params("sessionId")
 	m.mu.Lock()
 	session, ok := m.sessions[sessionId]


### PR DESCRIPTION
Limits incoming WebSocket messages to 4KB, preventing clients from consuming excessive server memory.